### PR TITLE
Handle large objects by storing binary buffers

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Zipped Redis Vault is a high-performance key-value storage solution that leverag
 - **Redis-Backed**: Utilizes Redis for fast, in-memory data storage and retrieval.
 - **Automatic Compression**: Values are automatically compressed with Zlib, optimizing storage space.
 - **Optional Encryption**: Offers the option to encrypt data before storage for enhanced security.
+- **Binary Serialization**: Large objects are serialized using the Node.js `v8` module to avoid JSON size limits. Older JSON formatted values remain readable.
 
 ## Dependencies
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 const redis = require('redis');
 const zlib = require('zlib');
+const v8 = require('v8');
 const encryption = require('./encryption');
 const config = require('./config')
 
@@ -45,26 +46,38 @@ class RedisStore {
     if (!this.connected) await this.waitForConnection();
 
     try {
-      let result = await this.client.get(`keyv:${key}`);
+      const raw = await this.client.getBuffer(`keyv:${key}`);
+      if (raw === null) return null;
 
+      // Attempt to parse legacy JSON format
       try {
-        result = JSON.parse(result);
-        if (result._compressed) {
-          const buffer = Buffer.from(result._compressed);
-          let decompressed = zlib.gunzipSync(buffer).toString();
+        const legacy = JSON.parse(raw.toString());
+        if (legacy._compressed) {
+          const buf = Buffer.from(legacy._compressed.data || legacy._compressed);
+          let decompressed = zlib.gunzipSync(buf).toString();
 
           if (config.secretKeys.includes(key)) {
             decompressed = encryption.decrypt(decompressed);
           }
 
-          result = JSON.parse(decompressed);
+          return JSON.parse(decompressed);
         }
       } catch (e) {
-        if (result || result === null) return result;
-        console.error(e);
+        // not legacy JSON format, proceed
       }
 
-      return result.value || result;
+      // New binary format
+      let decompressed = zlib.gunzipSync(raw).toString();
+
+      if (config.secretKeys.includes(key)) {
+        decompressed = encryption.decrypt(decompressed);
+      }
+
+      try {
+        return JSON.parse(decompressed);
+      } catch (err) {
+        return v8.deserialize(Buffer.from(decompressed, 'base64'));
+      }
     } catch (error) {
       console.error(`Couldn't get key ${key}`);
       return null;
@@ -80,17 +93,17 @@ class RedisStore {
   async set(key, value) {
     if (!this.connected) await this.waitForConnection();
 
-    let serializedValue = JSON.stringify(value);
+    let serialized = v8.serialize(value);
+    let dataString = serialized.toString('base64');
 
     if (config.secretKeys.includes(key)) {
-      serializedValue = encryption.encrypt(serializedValue);
+      dataString = encryption.encrypt(dataString);
     }
 
-    const userBuffer = Buffer.from(serializedValue);
-    const compressedValue = {_compressed: zlib.gzipSync(userBuffer)};
+    const compressed = zlib.gzipSync(Buffer.from(dataString));
 
     this.client.set(`keyv:update_time:${key}`, new Date().toString());
-    return this.client.set(`keyv:${key}`, JSON.stringify(compressedValue));
+    return this.client.set(`keyv:${key}`, compressed);
   }
 
   /**

--- a/test/redisStore.test.js
+++ b/test/redisStore.test.js
@@ -1,10 +1,13 @@
+process.env.SECRET = 'testSecret';
+process.env.SECRET_KEYS = 'secretKey';
+
 const chai = require('chai');
 const assert = chai.assert;
-const RedisStore = require('../index'); // Update the path accordingly
-const {encrypt, decrypt} = require('../encryption'); // Update the path accordingly
-const crypto = require('crypto-js');
+const RedisStore = require('../index');
+const { encrypt, decrypt } = require('../encryption');
 const cfg = require('../config');
 const zlib = require('zlib');
+const v8 = require('v8');
 describe('RedisStore', function () {
 
   before(async function () {
@@ -26,27 +29,33 @@ describe('RedisStore', function () {
     });
 
     it('should store encrypted data if key is in secretKeys', async function () {
-      const secretKey = cfg.secretKeys[0]; // Assuming the cfg has at least one secretKey
+      const secretKey = cfg.secretKeys[0];
       const value = 'testValue';
 
       await RedisStore.set(secretKey, value);
-      const rawRetrievedData = await RedisStore.client.get(`keyv:${secretKey}`);
+      const rawRetrievedData = await RedisStore.client.getBuffer(`keyv:${secretKey}`);
 
-      // Now, we'll simulate the processing done by the 'get' method in the RedisStore
-      let processedData = JSON.parse(rawRetrievedData);
-
-      if (processedData._compressed) {
-        const buffer = Buffer.from(processedData._compressed);
-        let decompressed = zlib.gunzipSync(buffer).toString();
-
-        if (cfg.secretKeys.includes(secretKey)) {
-          decompressed = decrypt(decompressed);
-        }
-
-        processedData = JSON.parse(decompressed);
+      let decompressed = zlib.gunzipSync(rawRetrievedData).toString();
+      if (cfg.secretKeys.includes(secretKey)) {
+        decompressed = decrypt(decompressed);
       }
+      const processedData = v8.deserialize(Buffer.from(decompressed, 'base64'));
 
       assert.equal(processedData, value);
+    });
+
+    it('should read legacy formatted values', async function () {
+      const key = 'legacyKey';
+      const value = { foo: 'bar' };
+
+      // Manually store value using legacy format
+      const serialized = JSON.stringify(value);
+      const userBuffer = Buffer.from(serialized);
+      const compressed = { _compressed: zlib.gzipSync(userBuffer) };
+      await RedisStore.client.set(`keyv:${key}`, JSON.stringify(compressed));
+
+      const result = await RedisStore.get(key);
+      assert.deepEqual(result, value);
     });
   });
 


### PR DESCRIPTION
## Summary
- use v8 serialization and store gzip buffers directly in Redis
- fallback to previous JSON format for backward compatibility
- update tests for new binary storage and legacy check
- document binary serialization feature

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840a8b69b848326a9414777ba2a5739